### PR TITLE
Add info on running in non-Vagrant envs to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,55 @@
 # dropwizard-kafka-http
 
-This project creates an Apache Kafka HTTP endpoint for producing and consuming messages.
+This project creates an Apache Kafka HTTP endpoint for producing and consuming
+messages. It is built on [the Dropwizard framework] that makes Java REST
+services operator-friendly and easy to deploy.
 
-## Running Project
+## Running in Development with Vagrant
 
-1) Install Vagrant [http://www.vagrantup.com/](http://www.vagrantup.com/)  
-2) Install Virtual Box [https://www.virtualbox.org/](https://www.virtualbox.org/)  
-3) git clone https://github.com/stealthly/dropwizard-kafka-http
-4) cd dropwizard-kafka-http    
-5) vagrant up    
-6) `curl -d "topic=http&message=hello&key=0" "http://192.168.22.10:8080/message"`    
-7) `curl "http://192.168.22.10:8080/message?topic=http"`    
+A `Vagrantfile` is included in the project to quickly get up and running with
+virtual machines to run ZooKeeper, Kafka, and the HTTP endpoint.
 
-Your original message produced from the consumer `[{"topic":"http","key":"0","message":"hello","partition":0,"offset":0}]`
+1. Install Vagrant <http://www.vagrantup.com/>
+2. Install Virtual Box <https://www.virtualbox.org/>
+3. `git clone https://github.com/stealthly/dropwizard-kafka-http`
+4. `cd dropwizard-kafka-http`
+5. `vagrant up`
+6. `curl -d "topic=http&message=hello&key=0" "http://192.168.22.10:8080/message"`
+7. `curl "http://192.168.22.10:8080/message?topic=http"`
+
+Your original message produced from the consumer:
+
+    [{"topic":"http","key":"0","message":"hello","partition":0,"offset":0}]
 
 * Zookeeper will be running on 192.168.22.5
 * dropwizard-kafka-http is built cleanly before Zookeeper installs in `vagrant/zk.sh`
-* Broker One is running on 192.168.22.10
+* Kafka Broker One is running on 192.168.22.10
 * dropwizard-kafka-http launches on 192.168.22.10 after the Kafka Broker starts in `vagrant/broker.sh`
 
-If you want you can login to the machines using `vagrant ssh zookeeper` and `vagrant ssh brokerOne`.    
+If you want you can log in to the machines using `vagrant ssh zookeeper` and `vagrant ssh brokerOne`.
+
+## Running in Your Own Environments
+
+For deployment, you'll need to build the project with Maven. Dropwizard projects
+produce "fat jars" so that you'll get a standalone binary ready to distribute
+and run with your production Java runtime. Assuming that ZooKeeper and Kafka are
+already running, edit the included `kafka-http.yml` to reflect the appropriate
+addresses for the HTTP endpoint to connect to these services.
+
+Then, use the [standard `server` Dropwizard command][dw server] to start up the
+HTTP server on port 8080, passing the config file as argument:
+
+    $ mvn package
+    $ java -jar target/dropwizard-kafka-http-0.0.1-SNAPSHOT.jar server kafka-http.yml
+    $ curl -d "topic=http&message=hello&key=0" http://localhost:8080/message
+    $ curl "http://localhost:8080/message?topic=http"
+
+You will also find an operator's interface with metrics and other info on port
+8081.
+
+It is recommended that you run the process under your preferred init or service
+supervision tool. See [the Dropwizard configuration reference] for extensive
+customization options for the HTTP server, logging, etc.
 
 ## dropwizard-kafka-http api methods
 
@@ -60,4 +90,8 @@ timeout - optional timeout in ms
 Errors:
 400     - wrong parameters passed
 ```
+
+[the Dropwizard framework]: http://dropwizard.github.io/dropwizard/
+[dw server]: http://dropwizard.github.io/dropwizard/getting-started.html#running-your-application
+[the Dropwizard configuration reference]: http://dropwizard.github.io/dropwizard/manual/configuration.html
 


### PR DESCRIPTION
Hi,

When I first looked at the project, I wished that it told me how to run it in real environments. So I did that. Fixes some little Markdown issues too like numbered list syntax.

I also wish that the README told me about some things like the concurrency model. I'm still testing it myself and also getting acquainted with Kafka's Java APIs that are used, as well as Dropwizard/Jetty, in order to understand this, but if any maintainers can add that info it'd be great.
